### PR TITLE
Better end game

### DIFF
--- a/src/game.rs
+++ b/src/game.rs
@@ -87,7 +87,7 @@ impl Default for GameInfo {
             black_rank: Rank::none(),
             white_rank: Rank::none(),
 
-            end_game: EndGame::None,
+            end_game: EndGame::NotOver,
         }
     }
 }

--- a/src/game.rs
+++ b/src/game.rs
@@ -17,7 +17,7 @@ pub enum Marker {
     Label(char),
 }
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 #[allow(unused)]
 pub enum Event {
     Start,
@@ -72,6 +72,8 @@ pub struct GameInfo {
     pub white_player: String,
     pub black_rank: Rank,
     pub white_rank: Rank,
+
+    pub end_game: EndGame,
 }
 impl Default for GameInfo {
     fn default() -> Self {
@@ -84,6 +86,8 @@ impl Default for GameInfo {
             white_player: String::from("White"),
             black_rank: Rank::none(),
             white_rank: Rank::none(),
+
+            end_game: EndGame::None,
         }
     }
 }
@@ -99,7 +103,6 @@ pub struct Game {
     rules: Rules,
 
     pub info: GameInfo,
-    pub end_game: Option<EndGame>,
 }
 impl Game {
     pub fn builder() -> NewGameBuilder {
@@ -142,7 +145,7 @@ impl Game {
 
     pub fn undo(&mut self) {
         self.pop_history();
-        self.build_board_from_history(&self.history.get_path());
+        self.build_board_from_history(&self.history.get_history());
     }
 
     fn pop_history(&mut self) -> Option<Event> {
@@ -151,22 +154,22 @@ impl Game {
 
     pub fn move_back(&mut self) {
         self.history.move_to_parent();
-        self.build_board_from_history(&self.history.get_path());
+        self.build_board_from_history(&self.history.get_history());
     }
 
     pub fn move_forward(&mut self) {
         self.history.move_to_first_child();
-        self.build_board_from_history(&self.history.get_path());
+        self.build_board_from_history(&self.history.get_history());
     }
 
     pub fn move_up(&mut self) {
         self.history.move_to_last_sibling();
-        self.build_board_from_history(&self.history.get_path());
+        self.build_board_from_history(&self.history.get_history());
     }
 
     pub fn move_down(&mut self) {
         self.history.move_to_next_sibling();
-        self.build_board_from_history(&self.history.get_path());
+        self.build_board_from_history(&self.history.get_history());
     }
 
     pub fn black_prisoners(&self) -> u32 {
@@ -199,7 +202,7 @@ impl Game {
             }
             Event::Pass => self.turn = self.turn.swap(),
 
-            Event::Resign(s) => self.end_game = Some(EndGame::Resign(*s)),
+            Event::Resign(s) => self.info.end_game = EndGame::Resign(*s),
 
             Event::Mark(m, x, y) => {
                 if !self.current_board.set_marker(*m, *x, *y) {
@@ -214,6 +217,21 @@ impl Game {
 
     pub fn size(&self) -> (usize, usize) {
         (self.current_board.width(), self.current_board.height())
+    }
+
+    pub fn ended(&self) -> bool {
+        let mut path = self.history.get_history();
+
+        if let Some(Event::Resign(_)) = path.last() {
+            return true;
+        }
+
+        if path.pop() == Some(Event::Pass)
+        && path.pop() == Some(Event::Pass) {
+            return true;
+        }
+
+        return false;
     }
 }
 
@@ -234,7 +252,6 @@ impl NewGameBuilder {
 
             turn: Stone::Black,
             rules: self.rules,
-            end_game: None,
 
             info: self.info.clone(),
         }

--- a/src/game.rs
+++ b/src/game.rs
@@ -222,12 +222,12 @@ impl Game {
     pub fn ended(&self) -> bool {
         let mut path = self.history.get_history();
 
-        if let Some(Event::Resign(_)) = path.last() {
+        if path.pop() == Some(Event::Pass)
+        && path.pop() == Some(Event::Pass) {
             return true;
         }
 
-        if path.pop() == Some(Event::Pass)
-        && path.pop() == Some(Event::Pass) {
+        if let Some(Event::Resign(_)) = path.last() {
             return true;
         }
 

--- a/src/game.rs
+++ b/src/game.rs
@@ -222,8 +222,7 @@ impl Game {
     pub fn ended(&self) -> bool {
         let mut path = self.history.get_history();
 
-        if path.pop() == Some(Event::Pass)
-        && path.pop() == Some(Event::Pass) {
+        if path.pop() == Some(Event::Pass) && path.pop() == Some(Event::Pass) {
             return true;
         }
 

--- a/src/rules.rs
+++ b/src/rules.rs
@@ -34,7 +34,7 @@ impl Rules {
 }
 
 /// The winner and method of winning
-#[derive(Clone)]
+#[derive(Clone, PartialEq)]
 #[allow(unused)]
 pub enum EndGame {
     // Score in half points
@@ -42,10 +42,12 @@ pub enum EndGame {
     Resign(Stone),
     Time(Stone),
     Forfiet(Stone),
+    None,
 }
 impl EndGame {
     pub fn display(&self) -> String {
         match self {
+            Self::None => String::from("Game not over."),
             Self::Score(s, p) => format!("{:?} won by {} points.", s, 0.5 * (*p as f32)),
             Self::Resign(s) => format!("{:?} won by resignation.", s),
             Self::Time(s) => format!("{:?} won by time.", s),

--- a/src/rules.rs
+++ b/src/rules.rs
@@ -51,7 +51,7 @@ impl EndGame {
             Self::Score(s, p) => format!("{:?} won by {} points.", s, 0.5 * (*p as f32)),
             Self::Resign(s) => format!("{:?} won by resignation.", s),
             Self::Time(s) => format!("{:?} won by time.", s),
-            Self::Forfiet(s) => format!("{:?} won by forfiet", s),
+            Self::Forfiet(s) => format!("{:?} won by forfiet.", s),
         }
     }
 }

--- a/src/rules.rs
+++ b/src/rules.rs
@@ -42,12 +42,12 @@ pub enum EndGame {
     Resign(Stone),
     Time(Stone),
     Forfiet(Stone),
-    None,
+    NotOver,
 }
 impl EndGame {
     pub fn display(&self) -> String {
         match self {
-            Self::None => String::from("Game not over."),
+            Self::NotOver => String::from("Game not over."),
             Self::Score(s, p) => format!("{:?} won by {} points.", s, 0.5 * (*p as f32)),
             Self::Resign(s) => format!("{:?} won by resignation.", s),
             Self::Time(s) => format!("{:?} won by time.", s),

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -56,7 +56,7 @@ impl EventTree {
         return current_node;
     }
 
-    pub fn get_path(&self) -> Vec<Event> {
+    pub fn get_history(&self) -> Vec<Event> {
         let mut vec = Vec::new();
         let mut current_node = &self.root;
 

--- a/src/ui/editor.rs
+++ b/src/ui/editor.rs
@@ -271,11 +271,31 @@ fn edit_game_info(ui: &mut Ui, info: &mut GameInfo) {
             }
 
             let before = *p;
+
+            // TODO: replae this with a number input box widget
+            ui.style_mut().spacing.slider_width *= 3.0;
             ui.add(
                 egui::Slider::new(p, 0..=400)
                     .show_value(false)
+                    .integer()
                     .text(format!("{}", 0.5*(before as f32)))
             );
+
+            ui.horizontal(|ui| {
+                if ui.button("-5").clicked() {
+                    *p -= 10
+                }
+                if ui.button("-0.5").clicked() {
+                    *p -= 1
+                }
+
+                if ui.button("+0.5").clicked() {
+                    *p += 1
+                }
+                if ui.button("+5").clicked() {
+                    *p += 10
+                }
+            });
         }
 
         _ => {}

--- a/src/ui/editor.rs
+++ b/src/ui/editor.rs
@@ -4,8 +4,8 @@ use egui::Ui;
 use super::board::{render_board, BoardStyle, Computed};
 use crate::game::Marker;
 use crate::game::{GameInfo, NewGameBuilder};
-use crate::rules::Rules;
 use crate::rules::EndGame;
+use crate::rules::Rules;
 use crate::{Event, Game, Stone};
 
 const LETTERS: &str = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
@@ -77,12 +77,10 @@ pub fn edit_game(ui: &mut Ui, g: &Game, style: &BoardStyle, editor: &mut Editor)
                 if let Some(e) = tool(ui, editor, &board, &game) {
                     game.handle_event(&e);
                 }
+            } else if game.info.end_game != EndGame::NotOver {
+                ui.label(game.info.end_game.display());
             } else {
-                if game.info.end_game != EndGame::NotOver {
-                    ui.label(game.info.end_game.display());
-                } else {
-                    ui.label("Game over. Edit the result of the game in `Game info`.");
-                }
+                ui.label("Game over. Edit the result of the game in `Game info`.");
             }
         });
 
@@ -244,10 +242,18 @@ fn edit_game_info(ui: &mut Ui, info: &mut GameInfo) {
         .selected_text(info.end_game.display())
         .show_ui(ui, |ui| {
             ui.selectable_value(&mut info.end_game, EndGame::NotOver, "Not over");
-            ui.selectable_value(&mut info.end_game, EndGame::Resign(Stone::Black), "Resignation");
+            ui.selectable_value(
+                &mut info.end_game,
+                EndGame::Resign(Stone::Black),
+                "Resignation",
+            );
             ui.selectable_value(&mut info.end_game, EndGame::Score(Stone::Black, 0), "Score");
             ui.selectable_value(&mut info.end_game, EndGame::Time(Stone::Black), "Time");
-            ui.selectable_value(&mut info.end_game, EndGame::Forfiet(Stone::Black), "Forfiet");
+            ui.selectable_value(
+                &mut info.end_game,
+                EndGame::Forfiet(Stone::Black),
+                "Forfiet",
+            );
         });
 
     match &mut info.end_game {
@@ -255,17 +261,17 @@ fn edit_game_info(ui: &mut Ui, info: &mut GameInfo) {
             if let Some(stone) = select_stone(ui) {
                 *s = stone;
             }
-        },
+        }
         EndGame::Time(s) => {
             if let Some(stone) = select_stone(ui) {
                 *s = stone;
             }
-        },
+        }
         EndGame::Forfiet(s) => {
             if let Some(stone) = select_stone(ui) {
                 *s = stone;
             }
-        },
+        }
 
         EndGame::Score(s, p) => {
             if let Some(stone) = select_stone(ui) {
@@ -280,7 +286,7 @@ fn edit_game_info(ui: &mut Ui, info: &mut GameInfo) {
                 egui::Slider::new(p, 0..=400)
                     .show_value(false)
                     .integer()
-                    .text(format!("{}", 0.5*(before as f32)))
+                    .text(format!("{}", 0.5 * (before as f32))),
             );
 
             ui.horizontal(|ui| {
@@ -307,13 +313,14 @@ fn edit_game_info(ui: &mut Ui, info: &mut GameInfo) {
 fn select_stone(ui: &mut Ui) -> Option<Stone> {
     ui.horizontal(|ui| {
         if ui.button("Black").clicked() {
-            return Some(Stone::Black)
+            return Some(Stone::Black);
         }
         if ui.button("White").clicked() {
-            return Some(Stone::White)
+            return Some(Stone::White);
         }
-        return None
-    }).inner
+        return None;
+    })
+    .inner
 }
 
 fn edit_rules(ui: &mut Ui, rules: &mut Rules) {

--- a/src/ui/editor.rs
+++ b/src/ui/editor.rs
@@ -5,6 +5,7 @@ use super::board::{render_board, BoardStyle, Computed};
 use crate::game::Marker;
 use crate::game::{GameInfo, NewGameBuilder};
 use crate::rules::Rules;
+use crate::rules::EndGame;
 use crate::{Event, Game, Stone};
 
 const LETTERS: &str = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
@@ -71,16 +72,16 @@ pub fn edit_game(ui: &mut Ui, g: &Game, style: &BoardStyle, editor: &mut Editor)
         ui.vertical(|ui| {
             editor_buttons(ui, editor, &mut game);
             let board = render_board(ui, &game.current_board(), style, size, &mut editor.computed);
-            match &game.end_game {
-                Some(e) => {
-                    ui.label(e.display());
+
+            if !game.ended() {
+                if let Some(e) = tool(ui, editor, &board, &game) {
+                    game.handle_event(&e);
                 }
-                None => {
-                    if let Some(e) = tool(ui, editor, &board, &game) {
-                        game.handle_event(&e);
-                    }
+            } else {
+                if game.info.end_game != EndGame::None {
+                    ui.label(game.info.end_game.display());
                 }
-            };
+            }
         });
 
         ui.vertical(|ui| {
@@ -235,6 +236,39 @@ fn edit_game_info(ui: &mut Ui, info: &mut GameInfo) {
         ui.label(info.white_rank.display());
     });
     ui.add(egui::Slider::new(&mut info.white_rank.0, -30..=9).show_value(false));
+
+    ui.label("End Game");
+    egui::ComboBox::from_id_source("End game editor")
+        .selected_text(info.end_game.display())
+        .show_ui(ui, |ui| {
+            ui.selectable_value(&mut info.end_game, EndGame::None, "None");
+            ui.selectable_value(&mut info.end_game, EndGame::Resign(Stone::Black), "Resignation");
+            ui.selectable_value(&mut info.end_game, EndGame::Score(Stone::Black, 0), "Score");
+            ui.selectable_value(&mut info.end_game, EndGame::Time(Stone::Black), "Time");
+            ui.selectable_value(&mut info.end_game, EndGame::Forfiet(Stone::Black), "Forfiet");
+        });
+
+    match &mut info.end_game {
+        EndGame::Resign(_) => {
+            if let Some(s) = select_stone(ui) {
+                info.end_game = EndGame::Resign(s);
+            }
+        },
+
+        _ => {ui.label("TODO");}
+    };
+}
+
+fn select_stone(ui: &mut Ui) -> Option<Stone> {
+    ui.horizontal(|ui| {
+        if ui.button("Black").clicked() {
+            return Some(Stone::Black)
+        }
+        if ui.button("White").clicked() {
+            return Some(Stone::White)
+        }
+        return None
+    }).inner
 }
 
 fn edit_rules(ui: &mut Ui, rules: &mut Rules) {

--- a/src/ui/editor.rs
+++ b/src/ui/editor.rs
@@ -78,7 +78,7 @@ pub fn edit_game(ui: &mut Ui, g: &Game, style: &BoardStyle, editor: &mut Editor)
                     game.handle_event(&e);
                 }
             } else {
-                if game.info.end_game != EndGame::None {
+                if game.info.end_game != EndGame::NotOver {
                     ui.label(game.info.end_game.display());
                 }
             }
@@ -241,7 +241,7 @@ fn edit_game_info(ui: &mut Ui, info: &mut GameInfo) {
     egui::ComboBox::from_id_source("End game editor")
         .selected_text(info.end_game.display())
         .show_ui(ui, |ui| {
-            ui.selectable_value(&mut info.end_game, EndGame::None, "None");
+            ui.selectable_value(&mut info.end_game, EndGame::NotOver, "Not over");
             ui.selectable_value(&mut info.end_game, EndGame::Resign(Stone::Black), "Resignation");
             ui.selectable_value(&mut info.end_game, EndGame::Score(Stone::Black, 0), "Score");
             ui.selectable_value(&mut info.end_game, EndGame::Time(Stone::Black), "Time");
@@ -252,6 +252,16 @@ fn edit_game_info(ui: &mut Ui, info: &mut GameInfo) {
         EndGame::Resign(_) => {
             if let Some(s) = select_stone(ui) {
                 info.end_game = EndGame::Resign(s);
+            }
+        },
+        EndGame::Time(_) => {
+            if let Some(s) = select_stone(ui) {
+                info.end_game = EndGame::Time(s);
+            }
+        },
+        EndGame::Forfiet(_) => {
+            if let Some(s) = select_stone(ui) {
+                info.end_game = EndGame::Forfiet(s);
             }
         },
 

--- a/src/ui/editor.rs
+++ b/src/ui/editor.rs
@@ -80,6 +80,8 @@ pub fn edit_game(ui: &mut Ui, g: &Game, style: &BoardStyle, editor: &mut Editor)
             } else {
                 if game.info.end_game != EndGame::NotOver {
                     ui.label(game.info.end_game.display());
+                } else {
+                    ui.label("Game over. Edit the result of the game in `Game info`.");
                 }
             }
         });
@@ -115,10 +117,10 @@ fn editor_buttons(ui: &mut Ui, editor: &mut Editor, game: &mut Game) {
     });
 
     ui.horizontal(|ui| {
-        if ui.button("Pass").clicked() {
+        if ui.button("Pass").clicked() && !game.ended() {
             game.handle_event(&Event::Pass);
         }
-        if ui.button("Resign").clicked() {
+        if ui.button("Resign").clicked() && !game.ended() {
             game.handle_event(&Event::Resign(game.turn))
         }
         if ui.button("Undo").clicked() {

--- a/src/ui/editor.rs
+++ b/src/ui/editor.rs
@@ -249,23 +249,36 @@ fn edit_game_info(ui: &mut Ui, info: &mut GameInfo) {
         });
 
     match &mut info.end_game {
-        EndGame::Resign(_) => {
-            if let Some(s) = select_stone(ui) {
-                info.end_game = EndGame::Resign(s);
+        EndGame::Resign(s) => {
+            if let Some(stone) = select_stone(ui) {
+                *s = stone;
             }
         },
-        EndGame::Time(_) => {
-            if let Some(s) = select_stone(ui) {
-                info.end_game = EndGame::Time(s);
+        EndGame::Time(s) => {
+            if let Some(stone) = select_stone(ui) {
+                *s = stone;
             }
         },
-        EndGame::Forfiet(_) => {
-            if let Some(s) = select_stone(ui) {
-                info.end_game = EndGame::Forfiet(s);
+        EndGame::Forfiet(s) => {
+            if let Some(stone) = select_stone(ui) {
+                *s = stone;
             }
         },
 
-        _ => {ui.label("TODO");}
+        EndGame::Score(s, p) => {
+            if let Some(stone) = select_stone(ui) {
+                *s = stone;
+            }
+
+            let before = *p;
+            ui.add(
+                egui::Slider::new(p, 0..=400)
+                    .show_value(false)
+                    .text(format!("{}", 0.5*(before as f32)))
+            );
+        }
+
+        _ => {}
     };
 }
 


### PR DESCRIPTION
Handle the end of the game better:
- [x] Edit `EndGame` from GameInfo
    - [x] set up
    - [x] implement all variants of `EndGame`
- [x] Stop play only if game is finished at current `EventNode`